### PR TITLE
update rgb output to functional notation, drops rgba

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,9 +26,9 @@ function hexToRgb(hex: string, opacity?: number): string {
       b: parseInt(result[3], 16),
     };
     if (opacity) {
-      return `rgba(${r}, ${g}, ${b}, ${opacity})`;
+      return `rgb(${r} ${g} ${b} / ${opacity})`;
     }
-    return `rgb(${r}, ${g}, ${b})`;
+    return `rgb(${r} ${g} ${b})`;
   }
   return hex;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -14,20 +14,20 @@ test("filterDeclarations()", function (t) {
 
   t.equal(
     useHct().process("a { color: hct(0, 0, 50); }").css,
-    "a { color: rgb(119, 119, 119); }",
-    "should convert hct(H, C, L) to rgb(R, G, B)."
+    "a { color: rgb(119 119 119); }",
+    "should convert hct(H, C, L) to rgb(R G B)."
   );
 
   t.equal(
     useHct().process("a { color: hct(0, 0%, 50%); }").css,
-    "a { color: rgb(119, 119, 119); }",
-    "should convert hct(H, C%, L%) to rgb(R, G, B)."
+    "a { color: rgb(119 119 119); }",
+    "should convert hct(H, C%, L%) to rgb(R G B)."
   );
 
   t.equal(
     useHct().process("a { color: hct(21, 70, 50, 0.5); }").css,
-    "a { color: rgba(211, 69, 71, 0.5); }",
-    "should convert hct(H, C, L, α) to rgba(R, G, B, α)."
+    "a { color: rgb(211 69 71 / 0.5); }",
+    "should convert hct(H, C, L, α) to rgba(R G B / α)."
   );
 
   t.equal(
@@ -38,7 +38,7 @@ test("filterDeclarations()", function (t) {
 
   t.equal(
     useHct().process("a { color: hct(180, 80, 80); }").css,
-    "a { color: rgb(0, 223, 190); }",
+    "a { color: rgb(0 223 190); }",
     "should return limited values when color is out of range."
   );
 


### PR DESCRIPTION
functional notation is widely supported now, but if you'd like to continue shipping rgba with comma separation, that's totally cool 🙂

<img width="663" alt="Screen Shot 2022-05-26 at 9 23 49 AM" src="https://user-images.githubusercontent.com/1134620/170531058-c9c31474-1317-410a-93d9-730aac84d148.png">
 